### PR TITLE
🧹 refactor: extract token path resolution into shared helper

### DIFF
--- a/src/builder/components.ts
+++ b/src/builder/components.ts
@@ -4,7 +4,7 @@ import { addComponent } from '@nuxt/kit'
 import type { Resolver } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleOptions } from '../types'
-import { debugLog } from '../utils'
+import { debugLog, resolveTokenPaths } from '../utils'
 import { flattenTokens } from '../utils/tokens'
 import { mergeTokenSource } from '../utils/token-merger'
 import { createPostCSSVPlugin } from '../postcss/postcss-v-function'
@@ -58,12 +58,11 @@ export async function setupComponents(
     if (!options.tokens) {
       if (debugMode) debugLog('No tokens file specified for CSS fallbacks.', 'warn')
     } else {
-      const projectPath = resolve(
+      const { projectPath, modulePath } = resolveTokenPaths(
         nuxt.options.rootDir,
-        'app/assets/styles/tokens',
+        resolver,
         options.tokens
       )
-      const modulePath = resolver.resolve(options.tokens)
 
       let rawTokens
       try {

--- a/src/builder/tokens.ts
+++ b/src/builder/tokens.ts
@@ -4,7 +4,7 @@ import { addTemplate, addPlugin } from '@nuxt/kit'
 import type { Resolver } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleOptions, TokensFile, TypedTokenValue } from '../types'
-import { debugLog } from '../utils'
+import { debugLog, resolveTokenPaths } from '../utils'
 import { mergeTokenSource } from '../utils/token-merger'
 import { parseTokens } from '../parser'
 
@@ -26,12 +26,11 @@ export async function setupTokens(
       return
     }
 
-    const projectPath = resolve(
+    const { projectPath, modulePath } = resolveTokenPaths(
       nuxt.options.rootDir,
-      'app/assets/styles/tokens',
+      resolver,
       options.tokens
     )
-    const modulePath = resolver.resolve(options.tokens)
 
     try {
       filePath = projectPath

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { resolve } from 'node:path'
+import type { Resolver } from '@nuxt/kit'
+
 // Module label for logging purposes.
 export const modLabel = '[DAREDASH] >>>> '
 
@@ -20,4 +23,22 @@ export function debugLog(
       console.log(`${modLabel} ${message}`, data || '')
     }
   }
+}
+
+/**
+ * Resolves the absolute paths for a tokens file, both in the project and in the module.
+ * @param {string} rootDir - The root directory of the Nuxt project.
+ * @param {Resolver} resolver - The resolver instance from @nuxt/kit.
+ * @param {string} tokenOption - The path to the tokens file from options.
+ * @returns {{ projectPath: string, modulePath: string }}
+ */
+export function resolveTokenPaths(
+  rootDir: string,
+  resolver: Resolver,
+  tokenOption: string
+) {
+  const projectPath = resolve(rootDir, 'app/assets/styles/tokens', tokenOption)
+  const modulePath = resolver.resolve(tokenOption)
+
+  return { projectPath, modulePath }
 }

--- a/test/utils/resolveTokenPaths.spec.ts
+++ b/test/utils/resolveTokenPaths.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveTokenPaths } from '../../src/utils'
+import { resolve } from 'path'
+
+describe('resolveTokenPaths', () => {
+  it('should resolve both project and module paths correctly', () => {
+    const rootDir = '/project/root'
+    const tokenOption = 'my-tokens.json'
+    const resolver = {
+      resolve: vi.fn((path) => `/module/path/${path}`)
+    }
+
+    const result = resolveTokenPaths(rootDir, resolver, tokenOption)
+
+    expect(result.projectPath).toBe(resolve(rootDir, 'app/assets/styles/tokens', tokenOption))
+    expect(result.modulePath).toBe(`/module/path/${tokenOption}`)
+    expect(resolver.resolve).toHaveBeenCalledWith(tokenOption)
+  })
+})


### PR DESCRIPTION
This PR addresses a code health issue where token path resolution logic was duplicated in two different parts of the build process.

🎯 **What:** 
- Created a `resolveTokenPaths` helper function in `src/utils.ts` that centralizes the logic for determining the project-specific and module-default paths for token files.
- Refactored `src/builder/tokens.ts` and `src/builder/components.ts` to use this new helper.

💡 **Why:** 
- Reduces code duplication, making the logic easier to maintain and update in one place.
- Improves readability of the build-time logic.

✅ **Verification:** 
- Added a new unit test suite `test/utils/resolveTokenPaths.spec.ts` covering the new utility.
- Ran existing tests using `bun test` to ensure no regressions in core token parsing and utility functions.

✨ **Result:** 
- A cleaner, more maintainable codebase with centralized path resolution for design tokens.

---
*PR created automatically by Jules for task [3199985425311693763](https://jules.google.com/task/3199985425311693763) started by @pisandelli*