### PR TITLE
🔒 [security] Sanitize href config in Breadcrumb and related components

### DIFF
--- a/runtime/components/primitives/Breadcrumb/Breadcrumb.security.test.ts
+++ b/runtime/components/primitives/Breadcrumb/Breadcrumb.security.test.ts
@@ -44,4 +44,21 @@ describe('Breadcrumb Security', () => {
     // The text content should contain the payload as literal text
     expect(wrapper.html()).toContain('&lt;script id="xss-separator"&gt;alert("xss-separator")&lt;/script&gt;')
   })
+
+  it('sanitizes javascript: URIs in href', async () => {
+    const xssPayload = 'javascript:alert("xss")'
+    const wrapper = await mountSuspended(Breadcrumb, {
+      props: {
+        config: {
+          routes: [
+            { label: 'Home', href: xssPayload },
+            { label: 'End' }
+          ]
+        }
+      }
+    })
+
+    const link = wrapper.find('a')
+    expect(link.attributes('href')).toBe('about:blank')
+  })
 })

--- a/runtime/components/primitives/Breadcrumb/Breadcrumb.ts
+++ b/runtime/components/primitives/Breadcrumb/Breadcrumb.ts
@@ -4,6 +4,7 @@ import { NuxtLink, Icon } from '#components'
 import { useBaseComponent } from '#dd/composables/useBaseComponent'
 import styles from '#dd/styles/Breadcrumb.module.css'
 import getPrefixName from '#dd/utils/getPrefixName'
+import { sanitizeHref } from '#dd/utils/sanitizeHref'
 
 export interface BreadcrumbItem {
   label: string;
@@ -77,7 +78,7 @@ export default defineNuxtComponent({
             NuxtLink as any,
             {
               to: item.to,
-              href: item.href,
+              href: sanitizeHref(item.href),
               class: [styles.item, styles.link],
               style: renderItemDynamicStyle(item),
               ...(item.disabled ? { disabled: true, 'aria-disabled': 'true' } : {})

--- a/runtime/components/primitives/Button/Button.ts
+++ b/runtime/components/primitives/Button/Button.ts
@@ -4,6 +4,7 @@ import { NuxtLink, Icon } from '#components'
 import { useBaseComponent } from '#dd/composables/useBaseComponent'
 import styles from '#dd/styles/Button.module.css'
 import getPrefixName from '#dd/utils/getPrefixName'
+import { sanitizeHref } from '#dd/utils/sanitizeHref'
 
 export default defineNuxtComponent({
   name: 'Button',
@@ -82,7 +83,7 @@ export default defineNuxtComponent({
         ...(defineColor.value ? { style: buttonStyle.value } : {}),
         'data-icon-only': isIconOnly.value ? '' : undefined,
         ...(props.to && { to: props.to }),
-        ...(props.href && { href: props.href })
+        ...(props.href && { href: sanitizeHref(props.href) })
       }
 
       return h(component.value as any, renderProps, {

--- a/runtime/components/widgets/Anchor/Anchor.ts
+++ b/runtime/components/widgets/Anchor/Anchor.ts
@@ -2,6 +2,7 @@ import { defineNuxtComponent } from 'nuxt/app'
 import { h, ref, onMounted, onUnmounted, type PropType, type VNode } from 'vue'
 import { useBaseComponent } from '#dd/composables/useBaseComponent'
 import styles from '#dd/styles/Anchor.module.css'
+import { sanitizeHref } from '#dd/utils/sanitizeHref'
 
 export interface AnchorItem {
   key: string
@@ -144,7 +145,7 @@ export default defineNuxtComponent({
         }, [
           h('a', {
             class: styles.link,
-            href: item.href,
+            href: sanitizeHref(item.href),
             onClick: (e: MouseEvent) => handleClick(e, item)
           }, titleContent)
         ])

--- a/runtime/components/widgets/Tabs/Tab.ts
+++ b/runtime/components/widgets/Tabs/Tab.ts
@@ -3,6 +3,7 @@ import { h, inject, onMounted, onUnmounted, computed, resolveComponent } from 'v
 import { useBaseComponent } from '#dd/composables/useBaseComponent'
 import getPrefixName from '#dd/utils/getPrefixName'
 import styles from '#dd/styles/Tabs.module.css'
+import { sanitizeHref } from '#dd/utils/sanitizeHref'
 import { Icon } from '#components'
 import { TabsContextKey, type TabsContext } from './Tabs'
 
@@ -111,7 +112,7 @@ export default defineNuxtComponent({
       }
 
       if (props.to) tabAttrs.to = props.to
-      if (props.href) tabAttrs.href = props.href
+      if (props.href) tabAttrs.href = sanitizeHref(props.href)
 
       const children = []
 

--- a/runtime/shared/utils/sanitizeHref.ts
+++ b/runtime/shared/utils/sanitizeHref.ts
@@ -1,0 +1,20 @@
+/**
+ * Sanitizes a URL to prevent Cross-Site Scripting (XSS) attacks by blocking 'javascript:' URIs.
+ *
+ * @param href - The URL to sanitize.
+ * @returns The sanitized URL or 'about:blank' if the URL is dangerous.
+ */
+export function sanitizeHref(href: string): string
+export function sanitizeHref(href: string | undefined): string | undefined
+export function sanitizeHref(href?: string): string | undefined {
+  if (!href) return href
+
+  // Remove whitespace and control characters that could be used to bypass 'javascript:' check
+  const normalizedHref = href.replace(/[\u0000-\u001F\u007F-\u009F\s]/g, '').toLowerCase()
+
+  if (normalizedHref.startsWith('javascript:')) {
+    return 'about:blank'
+  }
+
+  return href
+}

--- a/test/utils/sanitizeHref.spec.ts
+++ b/test/utils/sanitizeHref.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeHref } from '../../runtime/shared/utils/sanitizeHref'
+
+describe('sanitizeHref', () => {
+  it('allows safe http URLs', () => {
+    expect(sanitizeHref('http://example.com')).toBe('http://example.com')
+  })
+
+  it('allows safe https URLs', () => {
+    expect(sanitizeHref('https://example.com')).toBe('https://example.com')
+  })
+
+  it('allows relative paths', () => {
+    expect(sanitizeHref('/path/to/page')).toBe('/path/to/page')
+    expect(sanitizeHref('./path')).toBe('./path')
+    expect(sanitizeHref('../path')).toBe('../path')
+  })
+
+  it('allows hash links', () => {
+    expect(sanitizeHref('#section')).toBe('#section')
+  })
+
+  it('blocks javascript: URIs', () => {
+    expect(sanitizeHref('javascript:alert(1)')).toBe('about:blank')
+  })
+
+  it('blocks case-insensitive javascript: URIs', () => {
+    expect(sanitizeHref('javaScript:alert(1)')).toBe('about:blank')
+    expect(sanitizeHref('JAVASCRIPT:alert(1)')).toBe('about:blank')
+  })
+
+  it('blocks javascript: URIs with leading/trailing whitespace', () => {
+    expect(sanitizeHref(' javascript:alert(1)')).toBe('about:blank')
+    expect(sanitizeHref('javascript:alert(1) ')).toBe('about:blank')
+    expect(sanitizeHref('\tjavascript:alert(1)\n')).toBe('about:blank')
+  })
+
+  it('blocks javascript: URIs with bypass attempts using control characters', () => {
+    // Some browsers ignore \r, \n, \t in protocols
+    expect(sanitizeHref('java\nscript:alert(1)')).toBe('about:blank')
+    expect(sanitizeHref('java\rscript:alert(1)')).toBe('about:blank')
+    expect(sanitizeHref('java\tscript:alert(1)')).toBe('about:blank')
+  })
+
+  it('handles undefined and empty strings', () => {
+    expect(sanitizeHref(undefined)).toBe(undefined)
+    expect(sanitizeHref('')).toBe('')
+  })
+})


### PR DESCRIPTION
🎯 **What:** Fixed an XSS vulnerability in the `Breadcrumb` component where unvalidated `href` properties were directly bound to anchor tags. The fix was also proactively applied to `Button`, `Tab`, and `Anchor` components.

⚠️ **Risk:** Malicious users could provide `javascript:` URIs (e.g., `javascript:alert(document.cookie)`) in the `href` configuration, leading to Cross-Site Scripting (XSS) when a user clicks the affected link.

🛡️ **Solution:** 
1. Created a robust `sanitizeHref` utility in `runtime/shared/utils/sanitizeHref.ts` that:
   - Removes whitespace and control characters from the URL.
   - Blocks `javascript:` URIs by returning `about:blank`.
   - Allows safe URLs (http, https, relative paths, hashes).
2. Applied `sanitizeHref` to the following components:
   - `Breadcrumb`
   - `Button`
   - `Tab`
   - `Anchor`
3. Added unit tests for the utility in `test/utils/sanitizeHref.spec.ts`.
4. Added a security test case in `runtime/components/primitives/Breadcrumb/Breadcrumb.security.test.ts`.

---
*PR created automatically by Jules for task [7340243721713885525](https://jules.google.com/task/7340243721713885525) started by @pisandelli*