### PR TITLE
⚡ Parallelize token file reading in mergeTokenSource

### DIFF
--- a/src/utils/token-merger.ts
+++ b/src/utils/token-merger.ts
@@ -45,20 +45,25 @@ export async function mergeTokenSource(sourcePath: string): Promise<Record<strin
   if (stats.isDirectory()) {
     const files = await getJsonFiles(sourcePath)
     files.sort() // Ensure deterministic order
-    
+
+    const parsedFiles = await Promise.all(
+      files.map(async (file) => {
+        const content = await readFile(file, 'utf-8')
+        let parsed = JSON.parse(content)
+        parsed = parsed.default || parsed
+        return { file, parsed }
+      })
+    )
+
     let mergedTokens: Record<string, any> = {}
 
-    for (const file of files) {
-      const content = await readFile(file, 'utf-8')
-      let parsed = JSON.parse(content)
-      parsed = parsed.default || parsed
-
+    for (const { file, parsed } of parsedFiles) {
       const relPath = relative(sourcePath, file)
       const keys = relPath
         .replace(/\.json$/, '')
         .split(/[\\/]/)
 
-      let finalKeys = keys
+      const finalKeys = [...keys]
       if (finalKeys[finalKeys.length - 1] === 'index') {
         finalKeys.pop()
       }


### PR DESCRIPTION
💡 **What:** Refactored the `mergeTokenSource` function in `src/utils/token-merger.ts` to use `Promise.all` for concurrent file reading and parsing.
🎯 **Why:** The previous implementation used a sequential `await` inside a loop, which is an anti-pattern for I/O-bound tasks in Node.js. With dozens of JSON files (e.g., 42 in the default theme), this sequential approach significantly slows down the token merging process during build/runtime.
📊 **Measured Improvement:** In the current environment, a full benchmark was impractical due to missing dependencies and installation timeouts. However, by parallelizing 40+ I/O operations, the performance gain is theoretically proportional to the number of files and the I/O latency. Determinism was strictly preserved by keeping the merging logic sequential on the already loaded data.

---
*PR created automatically by Jules for task [4758427648483116329](https://jules.google.com/task/4758427648483116329) started by @pisandelli*