### PR TITLE
🧹 Remove unsafe type assertions from useAppConfig usage

### DIFF
--- a/runtime/components/primitives/Alert/Alert.vue
+++ b/runtime/components/primitives/Alert/Alert.vue
@@ -82,7 +82,7 @@ const handleClose = () => {
 
 // Check which string variance attribute we have by looking at processedAttrs keys
 const semanticIcon = computed(() => {
-  const appConfig = useAppConfig() as any
+  const appConfig = useAppConfig()
   const globalIcons = appConfig.daredash?.icons || {}
 
   // `processedAttrs` returns things like `{'data-success': ''}`
@@ -121,7 +121,7 @@ const resolvedIcon = computed(() => {
     </div>
 
     <button v-if="props.closable" type="button" :class="styles.close" aria-label="Close alert" @click="handleClose">
-      <Icon :name="(useAppConfig() as any).daredash?.icons?.toastClose || 'heroicons:x-mark'" />
+      <Icon :name="useAppConfig().daredash?.icons?.toastClose || 'heroicons:x-mark'" />
     </button>
   </div>
 </template>

--- a/runtime/components/primitives/Form/InputSearch.ts
+++ b/runtime/components/primitives/Form/InputSearch.ts
@@ -64,7 +64,7 @@ export default defineNuxtComponent({
   emits: ['update:modelValue', 'search'],
   setup(props, { attrs, emit }) {
     const { processedAttrs } = useBaseComponent(attrs, styles, 'InputSearch')
-    const appConfig = useAppConfig() as any
+    const appConfig = useAppConfig()
     const globalIcons = appConfig.daredash?.icons || {}
 
     const DdCluster = resolveComponent(

--- a/runtime/components/primitives/Form/Select.ts
+++ b/runtime/components/primitives/Form/Select.ts
@@ -73,7 +73,7 @@ export default defineNuxtComponent({
   emits: ['update:modelValue'],
   setup(props, { attrs, emit }) {
     const { processedAttrs } = useBaseComponent(attrs, {})
-    const appConfig = useAppConfig() as any
+    const appConfig = useAppConfig()
     const globalIcons = appConfig.daredash?.icons || {}
 
     // Handle input change

--- a/runtime/components/primitives/Toaster/Toast.ts
+++ b/runtime/components/primitives/Toaster/Toast.ts
@@ -29,7 +29,7 @@ export default defineNuxtComponent({
   emits: ['close'],
   setup(props, { slots, attrs, emit }): () => VNode {
     const { processedAttrs, classList } = useBaseComponent(attrs, styles)
-    const appConfig = useAppConfig() as any
+    const appConfig = useAppConfig()
     const globalIcons = appConfig.daredash?.icons || {}
 
     const iconName = computed(() => {

--- a/runtime/components/widgets/Drawer/Drawer.ts
+++ b/runtime/components/widgets/Drawer/Drawer.ts
@@ -60,7 +60,7 @@ export default defineNuxtComponent({
     )
 
     // AppConfig icons fallback
-    const appConfig = useAppConfig() as Record<string, any>
+    const appConfig = useAppConfig()
     const globalIcons = appConfig.daredash?.icons || {}
 
     // Resolve DareDash components dynamically

--- a/runtime/components/widgets/Modal/Modal.ts
+++ b/runtime/components/widgets/Modal/Modal.ts
@@ -46,7 +46,7 @@ export default defineNuxtComponent({
     )
 
     // AppConfig icons fallback
-    const appConfig = useAppConfig() as Record<string, any>
+    const appConfig = useAppConfig()
     const globalIcons = appConfig.daredash?.icons || {}
 
     // Resolve DareDash components dynamically

--- a/runtime/components/widgets/Pagination/Pagination.vue
+++ b/runtime/components/widgets/Pagination/Pagination.vue
@@ -63,7 +63,7 @@ const DdCluster = resolveComponent(
   getPrefixName('Cluster', { type: 'component' })
 )
 
-const appConfig = useAppConfig() as any
+const appConfig = useAppConfig()
 const globalIcons = appConfig.daredash?.icons || {}
 
 const totalPages = computed(() => {

--- a/runtime/components/widgets/Table/Table.vue
+++ b/runtime/components/widgets/Table/Table.vue
@@ -52,7 +52,7 @@ const props = withDefaults(defineProps<Props>(), {
 const attrs = useAttrs()
 const { processedAttrs, classList } = useBaseComponent(attrs, styles, 'Table')
 
-const appConfig = useAppConfig() as any
+const appConfig = useAppConfig()
 const globalIcons = appConfig.daredash?.icons || {}
 
 const DdLoading = resolveComponent(getPrefixName('Loading', { type: 'component' }))

--- a/runtime/types.d.ts
+++ b/runtime/types.d.ts
@@ -6,4 +6,26 @@ declare module 'nuxt/schema' {
       prefix: string
     }
   }
+
+  interface AppConfig {
+    daredash?: {
+      icons?: {
+        success?: string
+        error?: string
+        warning?: string
+        info?: string
+        toastClose?: string
+        selectArrow?: string
+        modalClose?: string
+        search?: string
+        loading?: string
+        drawerClose?: string
+        tableError?: string
+        emptyTable?: string
+        paginationPrev?: string
+        paginationNext?: string
+        [key: string]: string | undefined
+      }
+    }
+  }
 }


### PR DESCRIPTION
I have improved the codebase's health by addressing the unsafe use of `as any` type assertions when accessing `useAppConfig()`.

### Key Changes:
- **Type Augmentation:** Properly augmented the `AppConfig` interface in `runtime/types.d.ts` to include the `daredash.icons` schema.
- **Assertion Removal:** Removed `as any` and `as Record<string, any>` from 8 different components where `useAppConfig()` was being used.
- **Consistency:** Applied the fix across both primitive and widget components to ensure a uniform approach to configuration typing.

### Components Updated:
- `Alert.vue`
- `InputSearch.ts`
- `Select.ts`
- `Toast.ts`
- `Drawer.ts`
- `Modal.ts`
- `Table.vue`
- `Pagination.vue`

Verification was performed by checking the modified files and running available unit tests. While some component tests fail in this environment due to missing dependencies, my changes are purely type-level and do not affect runtime functionality.

---
*PR created automatically by Jules for task [9775280870331084206](https://jules.google.com/task/9775280870331084206) started by @pisandelli*