### PR TITLE
🔒 [security fix] Replace insecure Math.random() with secure ID generators

### DIFF
--- a/runtime/components/widgets/Accordion/AccordionGroup.ts
+++ b/runtime/components/widgets/Accordion/AccordionGroup.ts
@@ -1,5 +1,5 @@
 import { defineNuxtComponent } from 'nuxt/app'
-import { h, provide, type VNode } from 'vue'
+import { h, provide, type VNode, useId } from 'vue'
 import { useBaseComponent } from '#dd/composables/useBaseComponent'
 import getPrefixName from '#dd/utils/getPrefixName'
 import { resolveComponent } from 'vue'
@@ -37,9 +37,7 @@ export default defineNuxtComponent({
     )
 
     // Provide context to descendant Accordion items
-    const groupName = props.multiple
-      ? undefined
-      : `accordion-group-${Math.random().toString(36).substring(2, 9)}`
+    const groupName = props.multiple ? undefined : useId()
 
     provide(AccordionGroupInjectionKey, {
       name: groupName,

--- a/runtime/composables/useToaster.ts
+++ b/runtime/composables/useToaster.ts
@@ -17,7 +17,7 @@ export const useToaster = () => {
    * @param options An optional configuration object for the toast.
    */
   const showToast = (message: string, options: ToastOptions = {}) => {
-    const id = Date.now() + Math.random() // Unique ID
+    const id = crypto.randomUUID() // Unique ID
 
     const defaults: Omit<ToastMessage, 'id' | 'message'> = {
       type: 'info', // Default type
@@ -46,7 +46,7 @@ export const useToaster = () => {
    *
    * @param id The unique identifier of the notification to be dismissed.
    */
-  const dismissToast = (id: number) => {
+  const dismissToast = (id: string) => {
     const index: number = notifications.value.findIndex(
       (n: ToastMessage) => n.id === id
     )

--- a/runtime/shared/types/ToastMessage.ts
+++ b/runtime/shared/types/ToastMessage.ts
@@ -1,7 +1,7 @@
 export type ToastPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
 
 export type ToastMessage = {
-  id: number
+  id: string
   title?: string
   message: string
   type: 'success' | 'error' | 'info' | 'warning'

--- a/test/composables/useToaster.spec.ts
+++ b/test/composables/useToaster.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useToaster } from '../../runtime/composables/useToaster'
+
+// Mock nuxt/app
+vi.mock('nuxt/app', () => ({
+  useState: vi.fn((key, init) => ({ value: init ? init() : [] }))
+}))
+
+describe('useToaster', () => {
+  it('should generate a UUID for new toasts', () => {
+    const { showToast, notifications } = useToaster()
+
+    showToast('Test message')
+
+    expect(notifications.value).toHaveLength(1)
+    const toast = notifications.value[0]
+
+    // UUID v4 regex
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    // Note: crypto.randomUUID() might not always be v4 depending on the environment,
+    // but it usually follows this format.
+    // Let's just check if it's a string and has a certain length/format
+    expect(typeof toast.id).toBe('string')
+    expect(toast.id).toMatch(/^[0-9a-f-]+$/)
+    expect(toast.id.length).toBeGreaterThan(20)
+  })
+
+  it('should dismiss a toast by its string ID', () => {
+    const { showToast, dismissToast, notifications } = useToaster()
+
+    showToast('Test message')
+    const id = notifications.value[0].id
+
+    expect(notifications.value).toHaveLength(1)
+
+    dismissToast(id)
+
+    expect(notifications.value).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
🎯 **What:** Replaced insecure `Math.random()` with `useId()` for Accordion groups and `crypto.randomUUID()` for Toast notifications.

⚠️ **Risk:** `Math.random()` is not cryptographically secure and can lead to ID collisions or predictability. In SSR contexts, it can also cause hydration mismatches.

🛡️ **Solution:** Used `useId()` for stable, unique component IDs and `crypto.randomUUID()` for secure, unique toast IDs. Additionally updated types and added tests to ensure correctness.

---
*PR created automatically by Jules for task [3184001574765259603](https://jules.google.com/task/3184001574765259603) started by @pisandelli*