### PR TITLE
🔒 [security fix] Prevent Prototype Pollution in setNestedValue

### DIFF
--- a/runtime/composables/useThemeEditor.ts
+++ b/runtime/composables/useThemeEditor.ts
@@ -51,6 +51,9 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: strin
 
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i]!
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return
+    }
     if (typeof cursor[key] !== 'object' || cursor[key] === null) {
       cursor[key] = {}
     }
@@ -58,6 +61,9 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: strin
   }
 
   const leaf = keys[keys.length - 1]!
+  if (leaf === '__proto__' || leaf === 'constructor' || leaf === 'prototype') {
+    return
+  }
   if (typeof cursor[leaf] !== 'object' || cursor[leaf] === null) {
     cursor[leaf] = {}
   }


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR fixes a Prototype Pollution vulnerability in the `setNestedValue` helper function within the `useThemeEditor` composable.

### ⚠️ Risk: The potential impact if left unfixed
If left unfixed, an attacker could provide a malicious token path (e.g., `__proto__.someKey`) that, when processed by `setNestedValue`, would add properties to the global `Object.prototype`. This could lead to various issues, including crashing the application, bypassing security checks, or even remote code execution depending on how the polluted properties are used elsewhere in the system.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix adds explicit checks for sensitive property names (`__proto__`, `constructor`, and `prototype`) during both the path traversal and the final leaf assignment. If any of these forbidden keys are detected in the path, the function returns early without making any modifications, thus neutralizing the pollution attempt.

---
*PR created automatically by Jules for task [9942917232779960008](https://jules.google.com/task/9942917232779960008) started by @pisandelli*