### PR TITLE
🧹 refactor: remove redundant console.log fallback in debugLog

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,6 @@ export function debugLog(
   data?: any
 ) {
   if (process.env.NODE_ENV === 'development') {
-    const logMethod =
-      console[type || 'log'] || console.log
-    logMethod(`${modLabel} ${message}`, data ??  '')
+    console[type || 'log'](`${modLabel} ${message}`, data ?? '')
   }
 }

--- a/test/utils/debugLog.spec.ts
+++ b/test/utils/debugLog.spec.ts
@@ -42,11 +42,4 @@ describe('debugLog', () => {
     debugLog('message with data', 'log', data)
     expect(console.log).toHaveBeenCalledWith(`${modLabel} message with data`, data)
   })
-
-  it('should fallback to console.log if specified type does not exist (though TypeScript should prevent this)', () => {
-    process.env.NODE_ENV = 'development'
-    // @ts-ignore
-    debugLog('invalid type message', 'invalid')
-    expect(console.log).toHaveBeenCalledWith(`${modLabel} invalid type message`, '')
-  })
 })


### PR DESCRIPTION
🎯 **What:** Removed the redundant `|| console.log` fallback in the `debugLog` function in `src/utils.ts` and simplified the code to directly call `console[type || 'log']`. I also removed the test from `test/utils/debugLog.spec.ts` that specifically tested this unnecessary fallback behavior.
💡 **Why:** The `type` parameter is constrained by TypeScript to valid console methods (`'log' | 'warn' | 'error' | 'info' | 'debug'`), meaning the fallback is technically dead code. Removing it makes the code simpler and more maintainable.
✅ **Verification:** Verified by running `bun test test/utils/debugLog.spec.ts` which confirmed that all valid logging scenarios continue to work correctly.
✨ **Result:** A more concise and readable `debugLog` utility function without any changes in runtime behavior for valid usage.

---
*PR created automatically by Jules for task [12516956008996995835](https://jules.google.com/task/12516956008996995835) started by @pisandelli*