### PR TITLE
🧹 [code health improvement]: fix use of explicit 'any' type in catch block

### DIFF
--- a/src/builder/tokens.ts
+++ b/src/builder/tokens.ts
@@ -39,8 +39,12 @@ export async function setupTokens(
         debugLog(`Attempting to load tokens from project path: ${filePath}`)
       tokens = (await mergeTokenSource(filePath)) as TokensFile
       if (debugMode) debugLog(`Successfully loaded tokens from project path.`)
-    } catch (projectError: any) {
-      if (projectError.code !== 'ENOENT') {
+    } catch (projectError: unknown) {
+      if (!(projectError instanceof Error)) {
+        throw projectError
+      }
+
+      if ((projectError as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw projectError
       }
 


### PR DESCRIPTION
🎯 **What:** Removed the explicit `any` type usage in a catch block for token path loading logic and replaced it with a type-safe `unknown` alternative.

💡 **Why:** Using `any` bypasses TypeScript's safety features, increasing the likelihood of unhandled behavior or runtime crashes when expecting a specific exception pattern. By using `unknown` and validating the structure using `instanceof` and narrowing the type to `NodeJS.ErrnoException`, the code explicitly handles Node file system errors effectively while explicitly propagating non-Error instances.

✅ **Verification:** Verified that linting passes (specifically looking out for no regressions) and that `test/parser.spec.ts` and `test/utils/resolveTokenPaths.spec.ts` pass, ensuring that the token loading fallback mechanism does not crash or break.

✨ **Result:** Improved type safety around exceptions in file path operations without mutating fallback behavior.

---
*PR created automatically by Jules for task [16719033638813742128](https://jules.google.com/task/16719033638813742128) started by @pisandelli*